### PR TITLE
Fix typo in Namespace dashboard

### DIFF
--- a/grafana/kubernetes/without-recording-rules/onzack-namespace-monitoring.json
+++ b/grafana/kubernetes/without-recording-rules/onzack-namespace-monitoring.json
@@ -1585,7 +1585,7 @@
               "refId": "used-limits-ratio"
             }
           ],
-          "title": "Namesapce CPU Cores Quota ($namespace)",
+          "title": "Namespace CPU Cores Quota ($namespace)",
           "transformations": [
             {
               "id": "merge",
@@ -1868,7 +1868,7 @@
               "refId": "used-limits-ratio"
             }
           ],
-          "title": "Namesapce Memory Quota ($namespace)",
+          "title": "Namespace Memory Quota ($namespace)",
           "transformations": [
             {
               "id": "merge",


### PR DESCRIPTION
- Capacity Management should really have "Namespace" written on the label, not "Namesapce"