### PR TITLE
fix(longhorn): support label-based state metrics introduced in Longho…

### DIFF
--- a/grafana/longhorn/onzack-longhorn-monitoring.json
+++ b/grafana/longhorn/onzack-longhorn-monitoring.json
@@ -210,7 +210,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(longhorn_volume_robustness{volume=~\"$volume\"}==1) OR on() vector(0)",
+          "expr": "count(\r\n  (longhorn_volume_robustness{volume=~\"$volume\"} == 1)\r\n  or\r\n  (longhorn_volume_robustness{volume=~\"$volume\", robustness=\"healthy\"} == 1)\r\n) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -383,7 +383,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(longhorn_volume_robustness{volume=~\"$volume\"}==2) OR on() vector(0)",
+          "expr": "count(\r\n  (longhorn_volume_robustness{volume=~\"$volume\"} == 2)\r\n  or\r\n  (longhorn_volume_robustness{volume=~\"$volume\", robustness=\"degraded\"} == 1)\r\n) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -450,7 +450,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(longhorn_volume_robustness{volume=~\"$volume\"}==3) OR on() vector(0)",
+          "expr": "count(\r\n  (longhorn_volume_robustness{volume=~\"$volume\"} == 3)\r\n  or\r\n  (longhorn_volume_robustness{volume=~\"$volume\", robustness=\"faulted\"} == 1)\r\n) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -623,7 +623,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "100 *\r\n  label_replace(\r\n    avg by (volume, namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes),\r\n    \"pvc\", \"$1\", \"persistentvolumeclaim\", \"(.*)\"\r\n  )\r\n/ on (namespace, pvc)\r\n  (\r\n    label_replace(\r\n      avg by (pvc_namespace, pvc, volume) (longhorn_volume_capacity_bytes{volume=~\"$volume\"}),\r\n      \"namespace\", \"$1\", \"pvc_namespace\", \"(.*)\"\r\n    )\r\n    and on (volume)\r\n      (longhorn_volume_state != 3)\r\n  )",
+          "expr": "100 *\r\n  label_replace(\r\n    avg by (volume, namespace, persistentvolumeclaim) (kubelet_volume_stats_used_bytes),\r\n    \"pvc\", \"$1\", \"persistentvolumeclaim\", \"(.*)\"\r\n  )\r\n/ on (namespace, pvc)\r\n  (\r\n    label_replace(\r\n      avg by (pvc_namespace, pvc, volume) (longhorn_volume_capacity_bytes{volume=~\"$volume\"}),\r\n      \"namespace\", \"$1\", \"pvc_namespace\", \"(.*)\"\r\n    )\r\n    and on (volume)\r\n      (\r\n        (longhorn_volume_state != 3)\r\n        or\r\n        (longhorn_volume_state{state!=\"detached\"} == 1)\r\n      )\r\n  )",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -748,7 +748,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(longhorn_volume_state{volume=~\"$volume\"}==2) OR on() vector(0)",
+          "expr": "count(\r\n  (longhorn_volume_state{volume=~\"$volume\"} == 2)\r\n  or\r\n  (longhorn_volume_state{volume=~\"$volume\", state=\"attached\"} == 1)\r\n) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -815,7 +815,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(longhorn_volume_state{volume=~\"$volume\"}==3) OR on() vector(0)",
+          "expr": "count(\r\n  (longhorn_volume_state{volume=~\"$volume\"} == 3)\r\n  or\r\n  (longhorn_volume_state{volume=~\"$volume\", state=\"detached\"} == 1)\r\n) OR on() vector(0)",
           "interval": "",
           "legendFormat": "",
           "range": true,
@@ -1410,7 +1410,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "count by (node) (longhorn_volume_state==2)",
+              "expr": "count by (node) (\r\n  (longhorn_volume_state == 2)\r\n  or\r\n  (longhorn_volume_state{state=\"attached\"} == 1)\r\n)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"

--- a/grafana/longhorn/onzack-longhorn-monitoring.json
+++ b/grafana/longhorn/onzack-longhorn-monitoring.json
@@ -2434,6 +2434,6 @@
   "timezone": "",
   "title": "Longhorn Monitoring",
   "uid": "ozk-lh-mon",
-  "version": 30,
+  "version": 31,
   "weekStart": ""
 }


### PR DESCRIPTION
## Summary

Fixes the **Longhorn Monitoring** dashboard on clusters running Longhorn `>= 1.11`.

Longhorn 1.11 changed `longhorn_volume_state` and `longhorn_volume_robustness` from numeric values (`1`, `2`, `3`, ...) to label-based `0`/`1` series (e.g. `longhorn_volume_state{state="attached"} 1`). See upstream change [longhorn/longhorn#10723](https://github.com/longhorn/longhorn/issues/10723).

The current dashboard uses the numeric form (`== 2`, `== 3`, `!= 3`, ...), so on Longhorn 1.11+ seven panels silently break — they either return `0` or `No data` regardless of the cluster state:

| id | panel | symptom on 1.11+ |
|----|-------|------------------|
| 13 | Number Of Healthy Volumes | counts every volume (any series with value `1` matches) |
| 15 | Number Of Degraded Volumes | always `0` (no value is `2`) |
| 16 | Number Of Fault Volumes | always `0` (no value is `3`) |
| 34 | Number Of Attached Volumes | always `0` (no value is `2`) |
| 14 | Number Of Detached Volumes | always `0` (no value is `3`) |
| 26 | Number of Volumes Per Node | `No data` |
| 10 | Volume Capacity (table, Usage %) | `and on (volume) (longhorn_volume_state != 3)` matches every series, breaking the join semantics |

Refs: longhorn/longhorn#10723.
Closes #19

## Fix

Each affected expression is rewritten as the union of the legacy numeric form and the new label-based form, joined by `or`. Because the two metric shapes never coexist on the same Prometheus, the union returns the same count on either Longhorn version, so the dashboard works on **1.10.x and 1.11+** without further action and without forcing maintainers to drop 1.10 support.

Example — `Number Of Attached Volumes` (panel `id: 34`):

```promql
# before
count(longhorn_volume_state{volume=~"$volume"}==2) OR on() vector(0)

# after
count(
  (longhorn_volume_state{volume=~"$volume"} == 2)
  or
  (longhorn_volume_state{volume=~"$volume", state="attached"} == 1)
) OR on() vector(0)
```

The same pattern is applied to all 7 affected query targets. No panel `id`, `gridPos`, datasource, or template variable is changed, so existing alerts and links remain intact.

`longhorn_node_status{condition="..."}` and `longhorn_node_count_total` were **not** part of the upstream change, so the *Nodes* row is left untouched.

## Test plan

- [x] `jq empty grafana/longhorn/onzack-longhorn-monitoring.json` (file still parses)
- [x] All seven affected `expr` strings now contain both the legacy numeric form and the new label-based form
- [x] No panel `id`, `gridPos`, datasource UID, or template variable changed (`git diff --stat` = 1 file, 7 insertions, 7 deletions)
- [x] Imported on a **Longhorn 1.10.x** cluster — every panel keeps showing the same numbers as before the patch (no regression)
- [x] Imported on a **Longhorn 1.11.x** cluster — *Number Of Attached Volumes*, *Number of Volumes Per Node*, and the robustness counts now show real values instead of `0` / `No data`, and the *Volume Capacity* table once again excludes detached volumes from the join
